### PR TITLE
Update to use github maven repo for bdk dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.3.1")
 
     // bitcoindevkit
-    implementation("org.bitcoindevkit.bdkjni:bdk-android:0.3.0-rc2")
+    implementation("org.bitcoindevkit.bdkjni:bdk-android:0.3.0")
 
     // qr codes
     implementation("androidmads.library.qrgenearator:QRGenearator:1.0.4")

--- a/app/src/main/java/com/goldenraven/bdksampleapp/wallet/TransactionsFragment.kt
+++ b/app/src/main/java/com/goldenraven/bdksampleapp/wallet/TransactionsFragment.kt
@@ -11,7 +11,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import com.goldenraven.bdksampleapp.R

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,12 @@ allprojects {
         google()
         mavenCentral()
         jcenter()
-        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.github.com/bitcoindevkit/bdk-jni")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_USERNAME")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }


### PR DESCRIPTION
To access GitHub maven repository you must edit or create a `~/.gradle/gradle.properties` file which must contain properties `gpr.user` with your GitHub username and `gpr.key` with a personal access token key with `read:package` permission.